### PR TITLE
Fix invalid device index bug

### DIFF
--- a/VoiceAssistant/speech/speech_recognizer.py
+++ b/VoiceAssistant/speech/speech_recognizer.py
@@ -1,9 +1,11 @@
 import speech_recognition as sr
+import pyaudio
 
+default_device_index = pyaudio.PyAudio().get_default_output_device_info()['index']
 
 def get_audio(timeout, sample_rate=48000, chunk_size=2048):
     r = sr.Recognizer()
-    with sr.Microphone(device_index=0, sample_rate=sample_rate, chunk_size=chunk_size) as source:
+    with sr.Microphone(device_index=default_device_index, sample_rate=sample_rate, chunk_size=chunk_size) as source:
         r.adjust_for_ambient_noise(source)
         try:
             audio = r.listen(source, timeout=timeout)


### PR DESCRIPTION
Błąd polegał na tym, że default'owe urządzenie nie zawsze musi mieć index 0 (w moim wypadku było to na przykład 8). Zaciągam więc default'owy index mikrofonu przez bibliotekę pyaudio.